### PR TITLE
3 core matchers

### DIFF
--- a/src/main/eo/org/eolang/hamcrest/assert-that.eo
+++ b/src/main/eo/org/eolang/hamcrest/assert-that.eo
@@ -213,3 +213,19 @@
         "a numeric value within <%s> of <%s>"
         operand
         err
+  # Decorates another Matcher, retaining the behaviour
+  # but allowing tests to be slightly more expressive.
+  [matcher] > is
+
+    [a] > match
+      matcher.match a > @
+
+    [] > describe-mismatch
+      describe-mismatch. > @
+        matcher
+
+    [] > description-of
+      sprintf > @
+        "is %s"
+        description-of.
+          matcher

--- a/src/main/eo/org/eolang/hamcrest/assert-that.eo
+++ b/src/main/eo/org/eolang/hamcrest/assert-that.eo
@@ -31,7 +31,7 @@
     matcher.match actual
     TRUE
     sprintf
-      "%s: Expected: %s but: %s"
+      "%s\nExpected: %s but: %s"
       if.
         reasons.is-empty
         ""
@@ -242,3 +242,23 @@
 
     [] > description-of
       "anything" > @
+
+  # Wraps an existing matcher, overriding its description with that specified.
+  # All other functions are delegated to the decorated matcher,
+  # including its mismatch description.
+  [matcher format args...] > described-as
+
+    [a] > match
+      matcher.match a > @
+
+    [] > describe-mismatch
+      describe-mismatch. > @
+        matcher
+
+    [] > description-of
+      sprintf > @
+        format
+        # @todo #17:30 Here we got an object printed
+        # instead of data. The .map [i] i.as-string didn't work.
+        # We need to convert varargs to data[] somehow.
+        args

--- a/src/main/eo/org/eolang/hamcrest/assert-that.eo
+++ b/src/main/eo/org/eolang/hamcrest/assert-that.eo
@@ -213,6 +213,7 @@
         "a numeric value within <%s> of <%s>"
         operand
         err
+
   # Decorates another Matcher, retaining the behaviour
   # but allowing tests to be slightly more expressive.
   [matcher] > is
@@ -229,3 +230,15 @@
         "is %s"
         description-of.
           matcher
+
+  # A matcher that always returns true.
+  [] > anything
+
+    [a] > match
+      TRUE > @
+
+    [] > describe-mismatch
+      "anything" > @
+
+    [] > description-of
+      "anything" > @

--- a/src/test/eo/org/eolang/hamcrest/anything-tests.eo
+++ b/src/test/eo/org/eolang/hamcrest/anything-tests.eo
@@ -1,0 +1,58 @@
+# MIT License
+#
+# Copyright (c) 2020-2022 Graur Andrew
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
++package org.eolang.hamcrest
++alias org.eolang.hamcrest.assert-that
++junit
+
+[] > anything-two-sum-test
+  assert-that > @
+    4.add 4
+    $.is
+      $.anything
+    "sum of anything is always true"
+
+[] > anything-two-strings-test
+  assert-that > @
+    "vice"
+    $.is
+      $.anything
+    "string of anything is always true"
+
+[] > anything-two-floats-sum-test
+  assert-that > @
+    4.2.add 3.9
+    $.is
+      $.anything
+    "sum of two floats of anything is always true"
+
+[] > anything-all-of-test
+  assert-that > @
+    FALSE
+    $.all-of
+      $.anything
+
+[] > anything-any-of-test
+  assert-that > @
+    FALSE
+    $.any-of
+      $.anything

--- a/src/test/eo/org/eolang/hamcrest/described-as-tests.eo
+++ b/src/test/eo/org/eolang/hamcrest/described-as-tests.eo
@@ -1,0 +1,37 @@
+# MIT License
+#
+# Copyright (c) 2020-2022 Graur Andrew
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
++package org.eolang.hamcrest
++alias org.eolang.hamcrest.assert-that
++junit
+
+# @todo #16:30 I assumed that we need to add
+# more tests and more varargs values after
+# fixing issue in objectionary/eo#623
+[] > two-sum-described-as-equal-to-test
+  assert-that > @
+    15.add 5
+    $.described-as
+      $.equal-to 20
+      "this message overrides matchers description, and add values: %s"
+      1
+    "described as test"

--- a/src/test/eo/org/eolang/hamcrest/is-tests.eo
+++ b/src/test/eo/org/eolang/hamcrest/is-tests.eo
@@ -1,0 +1,68 @@
+# MIT License
+#
+# Copyright (c) 2020-2022 Graur Andrew
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
++package org.eolang.hamcrest
++alias org.eolang.hamcrest.assert-that
++junit
+
+[] > is-two-sum-test
+  assert-that > @
+    4.add 4
+    $.is
+      $.equal-to 8
+    "is sum of two numbers "
+
+[] > is-two-strings-test
+  assert-that > @
+    "vice"
+    $.is
+      $.equal-to "vice"
+    "is string equal to another string"
+
+[] > is-two-floats-sum-test
+  assert-that > @
+    4.2.add 3.9
+    $.is
+      $.equal-to 8.1
+    "is sum of two floats are equal"
+
+[] > is-two-bools-test
+  assert-that > @
+    FALSE.not
+    $.is
+      $.equal-to TRUE
+    "is two bools are equal"
+
+[] > is-two-sum-greater-than-value-test
+  assert-that > @
+    14.add 4
+    $.is
+      $.greater-than 3
+    "is 14.add 4 greater than 3"
+
+[] > is-two-sub-greater-than-expr-test
+  assert-that > @
+    44.sub 3
+    $.is
+      $.greater-than
+        33.add 5
+    "is 44.sub 3 greater than 33.add 5"


### PR DESCRIPTION
Introduce Core matchers: `.is`,  `.anything ` and `described-as` objects